### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ To run the Rails server:
 3. Install Rails: `gem install rails`
 4. Install Postgres: `brew install postgresql`
 5. From the project root, install the dependencies: `bundle install`
-6. Start the server: `rails s`
+6. Start the server: `rails s -b 0.0.0.0 -p 3000`


### PR DESCRIPTION
`rails s` by itself does not grant local network access. This is a problem if you are not using iOS simulator to test the react native apps. There does seem to be a way to configure rails to use those parameters by default, but this works with the current set up.